### PR TITLE
TODO追加コンポーネントからcssのimportを削除

### DIFF
--- a/src/components/lv3/dialog/AddTodo.vue
+++ b/src/components/lv3/dialog/AddTodo.vue
@@ -203,7 +203,6 @@ export default Vue.extend({
 </script>
 
 <style module>
-@import '../../../assets/css/values.css';
 
 .title {
   font-size: .8rem;


### PR DESCRIPTION
cssを共通化してもらったので、AddTODOコンポーネントからもcssのimportを削除 ✂️ 