### PR TITLE
change メソッドが存在しないなどの理由でwarningがでていたため修正しました

### DIFF
--- a/src/components/lv3/AvatarName.vue
+++ b/src/components/lv3/AvatarName.vue
@@ -22,10 +22,24 @@ import WantTo from '~/components/lv1/WantTo.vue'
 import VIconPhoto from '~/components/icon/Photo.vue'
 
 export default Vue.extend({
-
   components: {
     WantTo,
     VIconPhoto
+  },
+  data() {
+    return {
+      avatar: false,
+      statuses: [
+        {label: '達成', count: 0},
+        {label: 'おせっかい', count: 0},
+        {label: 'スキル', count: 0},
+      ]
+    }
+  },
+  methods: {
+    change: function() {
+      return false
+    }
   }
 })
 </script>

--- a/src/components/lv3/CoverImage.vue
+++ b/src/components/lv3/CoverImage.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
-    <div :class="$style.target">
+    <div v-if="true" :class="$style.target">
       <label for="cover" :class="$style.coverUpload">
         <v-icon-photo :class="$style.cover" />
         <input :class="$style.uploadButton" id="cover" type="file" @change="change">
       </label>
     </div>
     <!-- TODO: カバー画像がアップロードされたらimgタグに差し替えたい -->
-    <!-- <img :src="cover" :class="$style.target"> -->
+    <img v-else :src="cover" :class="$style.target">
   </div>
 </template>
 
@@ -18,6 +18,11 @@ import VIconPhoto from '~/components/icon/Photo.vue'
 export default Vue.extend({
   components: {
     VIconPhoto
+  },
+  methods: {
+    change: function() {
+      return false
+    }
   }
 })
 </script>


### PR DESCRIPTION
https://github.com/shige-yuka/paras/compare/hotfix-avatarname-coverimage-warning?expand=1#diff-367fffb84e6b3c9895e288978c12a6b9R7 にある @change="change" と書かれていましたが存在しないメソッドを実行しようとしていたため一時的にmethodsに定義する形で追加しておきます。